### PR TITLE
Add website links for museums

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,18 +79,18 @@
 
   <script>
     const DATA = [
-      { id: 1, name: "Rijksmuseum", city: "Amsterdam", free: false, kids: true, temporary: true, theme: "Kunst & Geschiedenis" },
-      { id: 2, name: "Van Gogh Museum", city: "Amsterdam", free: false, kids: true, temporary: true, theme: "Kunst" },
-      { id: 3, name: "NEMO Science Museum", city: "Amsterdam", free: false, kids: true, temporary: true, theme: "Wetenschap" },
-      { id: 4, name: "Kunsthal", city: "Rotterdam", free: false, kids: true, temporary: true, theme: "Hedendaagse kunst" },
-      { id: 5, name: "Boijmans Depot", city: "Rotterdam", free: false, kids: false, temporary: false, theme: "Collectie" },
-      { id: 6, name: "Mauritshuis", city: "Den Haag", free: false, kids: true, temporary: true, theme: "Schilderkunst" },
-      { id: 7, name: "Frans Hals Museum", city: "Haarlem", free: false, kids: true, temporary: true, theme: "Schilderkunst" },
-      { id: 8, name: "Museum Ons' Lieve Heer op Solder", city: "Amsterdam", free: false, kids: true, temporary: false, theme: "Historie" },
-      { id: 9, name: "Het Spoorwegmuseum", city: "Utrecht", free: false, kids: true, temporary: true, theme: "Techniek & Historie" },
-      { id:10, name: "Stedelijk Museum", city: "Amsterdam", free: false, kids: true, temporary: true, theme: "Moderne kunst" },
-      { id:11, name: "Museum Arnhem", city: "Arnhem", free: false, kids: true, temporary: true, theme: "Kunst" },
-      { id:12, name: "Allard Pierson", city: "Amsterdam", free: true, kids: true, temporary: true, theme: "Erfgoed" }
+      { id: 1, name: "Rijksmuseum", city: "Amsterdam", free: false, kids: true, temporary: true, theme: "Kunst & Geschiedenis", url: "https://www.rijksmuseum.nl/" },
+      { id: 2, name: "Van Gogh Museum", city: "Amsterdam", free: false, kids: true, temporary: true, theme: "Kunst", url: "https://www.vangoghmuseum.nl/" },
+      { id: 3, name: "NEMO Science Museum", city: "Amsterdam", free: false, kids: true, temporary: true, theme: "Wetenschap", url: "https://www.nemosciencemuseum.nl/" },
+      { id: 4, name: "Kunsthal", city: "Rotterdam", free: false, kids: true, temporary: true, theme: "Hedendaagse kunst", url: "https://www.kunsthal.nl/" },
+      { id: 5, name: "Boijmans Depot", city: "Rotterdam", free: false, kids: false, temporary: false, theme: "Collectie", url: "https://www.boijmans.nl/depot" },
+      { id: 6, name: "Mauritshuis", city: "Den Haag", free: false, kids: true, temporary: true, theme: "Schilderkunst", url: "https://www.mauritshuis.nl/" },
+      { id: 7, name: "Frans Hals Museum", city: "Haarlem", free: false, kids: true, temporary: true, theme: "Schilderkunst", url: "https://www.franshalsmuseum.nl/" },
+      { id: 8, name: "Museum Ons' Lieve Heer op Solder", city: "Amsterdam", free: false, kids: true, temporary: false, theme: "Historie", url: "https://www.opsolder.nl/" },
+      { id: 9, name: "Het Spoorwegmuseum", city: "Utrecht", free: false, kids: true, temporary: true, theme: "Techniek & Historie", url: "https://www.spoorwegmuseum.nl/" },
+      { id:10, name: "Stedelijk Museum", city: "Amsterdam", free: false, kids: true, temporary: true, theme: "Moderne kunst", url: "https://www.stedelijk.nl/" },
+      { id:11, name: "Museum Arnhem", city: "Arnhem", free: false, kids: true, temporary: true, theme: "Kunst", url: "https://www.museumarnhem.nl/" },
+      { id:12, name: "Allard Pierson", city: "Amsterdam", free: true, kids: true, temporary: true, theme: "Erfgoed", url: "https://www.allardpierson.nl/" }
     ];
 
     const T = {
@@ -179,9 +179,12 @@
         card.className = "card";
         card.setAttribute("role", "listitem");
 
-        const title = document.createElement("div");
+        const title = document.createElement("a");
         title.className = "title";
         title.textContent = m.name;
+        title.href = m.url;
+        title.target = "_blank";
+        title.rel = "noopener";
 
         const meta = document.createElement("div");
         meta.style.color = "var(--muted)";


### PR DESCRIPTION
## Summary
- include official museum websites in the data set
- display museum names as links opening in a new tab

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac58d571f48326ae8d53c3cee58cc1