### PR TITLE
Fix missing museum links by restoring card header

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,6 +383,10 @@
         card.href = m.url;
         card.target = "_blank";
         card.rel = "noopener noreferrer";
+
+        const row = document.createElement("div");
+        row.className = "title-row";
+
         const title = document.createElement("span");
         title.className = "title";
         title.textContent = m.name;


### PR DESCRIPTION
## Summary
- restore missing `title-row` container so museum links and favorite buttons render

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7a343f708326bb3ec91d2868bcba