### PR TITLE
Add museum images and descriptions

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,16 +1,148 @@
 const DATA = [
-  { id: 1, name: "Rijksmuseum", city: "Amsterdam", free: false, kids: true, temporary: true, theme: "Kunst & Geschiedenis", url: "https://www.rijksmuseum.nl/" },
-  { id: 2, name: "Van Gogh Museum", city: "Amsterdam", free: false, kids: true, temporary: true, theme: "Kunst", url: "https://www.vangoghmuseum.nl/" },
-  { id: 3, name: "NEMO Science Museum", city: "Amsterdam", free: false, kids: true, temporary: true, theme: "Wetenschap", url: "https://www.nemosciencemuseum.nl/" },
-  { id: 4, name: "Kunsthal", city: "Rotterdam", free: false, kids: true, temporary: true, theme: "Hedendaagse kunst", url: "https://www.kunsthal.nl/" },
-  { id: 5, name: "Boijmans Depot", city: "Rotterdam", free: false, kids: false, temporary: false, theme: "Collectie", url: "https://www.boijmans.nl/depot/" },
-  { id: 6, name: "Mauritshuis", city: "Den Haag", free: false, kids: true, temporary: true, theme: "Schilderkunst", url: "https://www.mauritshuis.nl/" },
-  { id: 7, name: "Frans Hals Museum", city: "Haarlem", free: false, kids: true, temporary: true, theme: "Schilderkunst", url: "https://www.franshalsmuseum.nl/" },
-  { id: 8, name: "Museum Ons' Lieve Heer op Solder", city: "Amsterdam", free: false, kids: true, temporary: false, theme: "Historie", url: "https://www.opsolder.nl/" },
-  { id: 9, name: "Het Spoorwegmuseum", city: "Utrecht", free: false, kids: true, temporary: true, theme: "Techniek & Historie", url: "https://www.spoorwegmuseum.nl/" },
-  { id:10, name: "Stedelijk Museum", city: "Amsterdam", free: false, kids: true, temporary: true, theme: "Moderne kunst", url: "https://www.stedelijk.nl/" },
-  { id:11, name: "Museum Arnhem", city: "Arnhem", free: false, kids: true, temporary: true, theme: "Kunst", url: "https://www.museumarnhem.nl/" },
-  { id:12, name: "Allard Pierson", city: "Amsterdam", free: true, kids: true, temporary: true, theme: "Erfgoed", url: "https://www.allardpierson.nl/" }
+  {
+    id: 1,
+    name: "Rijksmuseum",
+    city: "Amsterdam",
+    free: false,
+    kids: true,
+    temporary: true,
+    theme: "Kunst & Geschiedenis",
+    url: "https://www.rijksmuseum.nl/",
+    img: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/55/Amsterdam_-_Rijksmuseum_-_2019.jpg/400px-Amsterdam_-_Rijksmuseum_-_2019.jpg",
+    desc: "Nationaal museum van Nederlandse kunst en geschiedenis."
+  },
+  {
+    id: 2,
+    name: "Van Gogh Museum",
+    city: "Amsterdam",
+    free: false,
+    kids: true,
+    temporary: true,
+    theme: "Kunst",
+    url: "https://www.vangoghmuseum.nl/",
+    img: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Van_Gogh_Museum_South_Facade_%282007%29.jpg/400px-Van_Gogh_Museum_South_Facade_%282007%29.jpg",
+    desc: "Collectie werken van Vincent van Gogh en tijdgenoten."
+  },
+  {
+    id: 3,
+    name: "NEMO Science Museum",
+    city: "Amsterdam",
+    free: false,
+    kids: true,
+    temporary: true,
+    theme: "Wetenschap",
+    url: "https://www.nemosciencemuseum.nl/",
+    img: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/Amsterdam_-_NEMO_-_panoramio.jpg/400px-Amsterdam_-_NEMO_-_panoramio.jpg",
+    desc: "Interactief museum over wetenschap en technologie."
+  },
+  {
+    id: 4,
+    name: "Kunsthal",
+    city: "Rotterdam",
+    free: false,
+    kids: true,
+    temporary: true,
+    theme: "Hedendaagse kunst",
+    url: "https://www.kunsthal.nl/",
+    img: "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Kunsthal_Rotterdam_01.JPG/400px-Kunsthal_Rotterdam_01.JPG",
+    desc: "Hedendaagse kunst en veelzijdige tentoonstellingen."
+  },
+  {
+    id: 5,
+    name: "Boijmans Depot",
+    city: "Rotterdam",
+    free: false,
+    kids: false,
+    temporary: false,
+    theme: "Collectie",
+    url: "https://www.boijmans.nl/depot/",
+    img: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/da/Depot_Boijmans_van_Beuningen_2019.jpg/400px-Depot_Boijmans_van_Beuningen_2019.jpg",
+    desc: "Publiek toegankelijk kunstdepot van Museum Boijmans Van Beuningen."
+  },
+  {
+    id: 6,
+    name: "Mauritshuis",
+    city: "Den Haag",
+    free: false,
+    kids: true,
+    temporary: true,
+    theme: "Schilderkunst",
+    url: "https://www.mauritshuis.nl/",
+    img: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/32/Den_Haag_Mauritshuis2.JPG/400px-Den_Haag_Mauritshuis2.JPG",
+    desc: "17e-eeuwse Nederlandse schilderkunst met het beroemde Meisje met de parel."
+  },
+  {
+    id: 7,
+    name: "Frans Hals Museum",
+    city: "Haarlem",
+    free: false,
+    kids: true,
+    temporary: true,
+    theme: "Schilderkunst",
+    url: "https://www.franshalsmuseum.nl/",
+    img: "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b2/Frans_Hals_Museum.jpg/400px-Frans_Hals_Museum.jpg",
+    desc: "Schilderijen van Frans Hals en Haarlemse meesters."
+  },
+  {
+    id: 8,
+    name: "Museum Ons' Lieve Heer op Solder",
+    city: "Amsterdam",
+    free: false,
+    kids: true,
+    temporary: false,
+    theme: "Historie",
+    url: "https://www.opsolder.nl/",
+    img: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Ons%27_Lieve_Heer_op_Solder_exterior.jpg/400px-Ons%27_Lieve_Heer_op_Solder_exterior.jpg",
+    desc: "Uniek 17e-eeuws grachtenpand met verborgen huiskerk."
+  },
+  {
+    id: 9,
+    name: "Het Spoorwegmuseum",
+    city: "Utrecht",
+    free: false,
+    kids: true,
+    temporary: true,
+    theme: "Techniek & Historie",
+    url: "https://www.spoorwegmuseum.nl/",
+    img: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Spoorwegmuseum_Rijksmonument_10730_Maliebaanstation_Utrecht.JPG/400px-Spoorwegmuseum_Rijksmonument_10730_Maliebaanstation_Utrecht.JPG",
+    desc: "Geschiedenis van het Nederlandse spoor met historische treinen."
+  },
+  {
+    id: 10,
+    name: "Stedelijk Museum",
+    city: "Amsterdam",
+    free: false,
+    kids: true,
+    temporary: true,
+    theme: "Moderne kunst",
+    url: "https://www.stedelijk.nl/",
+    img: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/Stedelijk_Museum_Amsterdam_2011.jpg/400px-Stedelijk_Museum_Amsterdam_2011.jpg",
+    desc: "Moderne en hedendaagse kunst en vormgeving."
+  },
+  {
+    id: 11,
+    name: "Museum Arnhem",
+    city: "Arnhem",
+    free: false,
+    kids: true,
+    temporary: true,
+    theme: "Kunst",
+    url: "https://www.museumarnhem.nl/",
+    img: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/53/Museum_Arnhem_Entrance_2019.jpg/400px-Museum_Arnhem_Entrance_2019.jpg",
+    desc: "Kunstmuseum met aandacht voor hedendaagse kunst en vormgeving."
+  },
+  {
+    id: 12,
+    name: "Allard Pierson",
+    city: "Amsterdam",
+    free: true,
+    kids: true,
+    temporary: true,
+    theme: "Erfgoed",
+    url: "https://www.allardpierson.nl/",
+    img: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Allard_Pierson_Museum_2010.JPG/400px-Allard_Pierson_Museum_2010.JPG",
+    desc: "Erfgoed en collecties van de Universiteit van Amsterdam, van oudheid tot heden."
+  }
 ];
 
 const T = {
@@ -128,6 +260,10 @@ function render() {
     card.href = m.url;
     card.target = "_blank";
     card.rel = "noopener noreferrer";
+    const img = document.createElement("img");
+    img.src = m.img;
+    img.alt = m.name;
+    img.className = "photo";
 
     const row = document.createElement("div");
     row.className = "title-row";
@@ -155,14 +291,20 @@ function render() {
     meta.style.color = "var(--muted)";
     meta.textContent = m.city + " • " + m.theme;
 
+    const desc = document.createElement("p");
+    desc.className = "desc";
+    desc.textContent = m.desc;
+
     const badges = document.createElement("div");
     badges.className = "badges";
     if (m.free)  badges.appendChild(badge(T[lang].free, "free"));
     if (m.kids)  badges.appendChild(badge(T[lang].kids, "kids"));
     if (m.temporary) badges.appendChild(badge(T[lang].temp, "temp"));
 
+    card.appendChild(img);
     card.appendChild(row);
     card.appendChild(meta);
+    card.appendChild(desc);
     card.appendChild(badges);
     list.appendChild(card);
   }

--- a/styles.css
+++ b/styles.css
@@ -152,6 +152,17 @@
   .card:hover{ transform:translateY(-1px); }
   .card:focus-visible{ outline:2px solid var(--accent); outline-offset:2px; }
 
+  .card .photo{
+    width:100%;
+    height:160px;
+    object-fit:cover;
+    border-radius:var(--s-8);
+  }
+
+  .card .desc{
+    margin:0;
+  }
+
   .title-row{ display:flex; justify-content:space-between; align-items:flex-start; gap:var(--s-8); }
   .title{ font-weight:600; color:var(--accent); display:inline-flex; align-items:center; gap:var(--s-4); }
   .title::after{ content:"↗"; font-size:.75rem; opacity:.6; }


### PR DESCRIPTION
## Summary
- extend museum dataset with image URLs and short Dutch descriptions for each museum
- render photos and descriptions in museum cards
- style card images and text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac906aa7708326bc8fb67033baacb2