### PR TITLE
Fix photo rendering by removing stray code

### DIFF
--- a/app.js
+++ b/app.js
@@ -269,20 +269,15 @@ function render() {
     card.target = "_blank";
     card.rel = "noopener noreferrer";
     const img = document.createElement("img");
-codex/add-photo-and-description-to-museums-r2ej9l
     img.loading = "lazy";
     img.src = m.img || placeholder(m.name);
     img.alt = m.name;
+    img.referrerPolicy = "no-referrer";
     img.className = "photo";
     img.onerror = () => {
       img.onerror = null;
       img.src = placeholder(m.name);
     };
-
-    img.src = m.img;
-    img.alt = m.name;
-    img.className = "photo";
- main
 
     const row = document.createElement("div");
     row.className = "title-row";


### PR DESCRIPTION
## Summary
- Remove stray debug strings in `app.js` that caused runtime errors
- Ensure each card image lazily loads, clears referrer, and falls back to a placeholder when loading fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9d0f34208326af06bf87050ddd73