### PR TITLE
Rename Tropenmuseum to Wereldmuseum Amsterdam

### DIFF
--- a/v2/data/musea.json
+++ b/v2/data/musea.json
@@ -92,14 +92,14 @@
   },
   {
     "id": 8,
-    "name": "Tropenmuseum",
+    "name": "Wereldmuseum Amsterdam",
     "city": "Amsterdam",
     "theme": "Wereldculturen",
-    "url": "https://www.tropenmuseum.nl/",
+    "url": "https://www.wereldmuseum.nl/",
     "free": false,
     "kids": true,
     "temporary": true,
-    "photo": "./assets/img/tropenmuseum.jpg",
+    "photo": "./assets/img/wereldmuseum-amsterdam.jpg",
     "description": "Verhalen en objecten over culturen uit de hele wereld.",
     "end": "2025-07-01"
   },


### PR DESCRIPTION
## Summary
- update museum data to reflect the new name Wereldmuseum Amsterdam
- rename Tropenmuseum image asset and update URL

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adb86b3c488326bd96ce7b4aababa5