### PR TITLE
chore: switch to Quicksand font

### DIFF
--- a/app.js
+++ b/app.js
@@ -247,7 +247,7 @@ function placeholder(name) {
   const svg = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 160'>` +
               `<rect width='400' height='160' fill='#d1d5db'/>` +
               `<text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle'` +
-              ` font-family='sans-serif' font-size='20' fill='#6b7280'>${name}</text></svg>`;
+              ` font-family='Quicksand, sans-serif' font-size='20' fill='#6b7280'>${name}</text></svg>`;
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>MuseumBuddy — Mini Demo</title>
   <meta name="description" content="MuseumBuddy mini demo met filters en tweetalige interface (NL/EN)." />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -42,7 +42,7 @@
   *{box-sizing:border-box}
   html,body{
     margin:0; padding:0;
-    font-family:'Inter',system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+    font-family:'Quicksand',system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
     background:var(--bg); color:var(--text);
     font-size:16px; line-height:1.55;
   }

--- a/v2/app.js
+++ b/v2/app.js
@@ -62,7 +62,7 @@ function placeholder(name="Museum"){
     `<svg xmlns='http://www.w3.org/2000/svg' width='1200' height='675'>`+
     `<rect width='100%' height='100%' fill='${bg}'/>`+
     `<text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' `+
-    `font-family='Inter, system-ui, sans-serif' font-size='42' fill='${fg}'>${text}</text>`+
+    `font-family='Quicksand, system-ui, sans-serif' font-size='42' fill='${fg}'>${text}</text>`+
     `</svg>`;
 }
 

--- a/v2/assets/img/rijksmuseum.svg
+++ b/v2/assets/img/rijksmuseum.svg
@@ -1,5 +1,5 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='1280' height='720' viewBox='0 0 1280 720'>
   <rect width='1280' height='720' fill='#e5e7eb'/>
   <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle'
-        font-family='Inter, system-ui, sans-serif' font-size='64' fill='#374151'>Rijksmuseum</text>
+        font-family='Quicksand, system-ui, sans-serif' font-size='64' fill='#374151'>Rijksmuseum</text>
 </svg>

--- a/v2/assets/img/van-gogh-museum.svg
+++ b/v2/assets/img/van-gogh-museum.svg
@@ -1,5 +1,5 @@
 <svg xmlns='http://www.w3.org/2000/svg' width='1280' height='720' viewBox='0 0 1280 720'>
   <rect width='1280' height='720' fill='#e5e7eb'/>
   <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle'
-        font-family='Inter, system-ui, sans-serif' font-size='64' fill='#374151'>Van Gogh Museum</text>
+        font-family='Quicksand, system-ui, sans-serif' font-size='64' fill='#374151'>Van Gogh Museum</text>
 </svg>

--- a/v2/index.html
+++ b/v2/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>MuseumBuddy v2 — Ontdek musea met beeld</title>
   <meta name="description" content="MuseumBuddy v2 — moderne, beeldrijke lijst van musea met zoeken en filters." />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>

--- a/v2/styles.css
+++ b/v2/styles.css
@@ -14,7 +14,7 @@
   --shadow:0 6px 20px rgba(0,0,0,.25);
 }
 *{box-sizing:border-box}
-html,body{margin:0;padding:0;font-family:'Inter',system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text);font-size:16px;line-height:1.55}
+html,body{margin:0;padding:0;font-family:'Quicksand',system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text);font-size:16px;line-height:1.55}
 a{color:inherit;text-decoration:none}
 .wrap{max-width:1040px;margin:0 auto;padding:var(--s-24) var(--s-16) var(--s-32)}
 header{position:sticky;top:0;backdrop-filter:blur(8px);border-bottom:1px solid var(--border);display:flex;align-items:center;justify-content:space-between;gap:var(--s-16);padding-bottom:var(--s-16);margin-bottom:var(--s-24)}


### PR DESCRIPTION
## Summary
- swap Google Fonts link to Quicksand
- default CSS font-family now Quicksand
- update JS placeholders and SVG assets to use Quicksand

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b80c0dcfec8326a4206a396197fd85